### PR TITLE
Adding unit tests and modifying PowerShell scripts to pass unit tests.

### DIFF
--- a/DscResources/MSFT_xMySqlDatabase/MSFT_xMySqlDatabase.psm1
+++ b/DscResources/MSFT_xMySqlDatabase/MSFT_xMySqlDatabase.psm1
@@ -1,49 +1,6 @@
-<#
-   DSC resource designed to create a database in a MySQL instance, given the parameters supplied as per schema.
-
-   Copyright (c) Microsoft Corporation, 2014
-#>
-
 # NOTE: LocalizedData isn't used in this resource as there are no interactive/user visible strings
 
-#constants
-$mySqlVersion = "5.6"
-$Debug = $true
-$MySQLExePath = "$env:ProgramFiles\mySql\Mysql Server 5.6\bin\mysql.exe"
-
-
-#########################################################################################################################################
-# Trace-Message ([string]$Message). If Debug flag is set to true, it writes a verbose message given the input parameter
-#########################################################################################################################################
-
-Function Trace-Message
-{
-    param([string] $Message)
-
-    if($Debug)
-    {
-        Write-Verbose $Message
-    }
-}
-
-#########################################################################################################################################
-# Set-MySqlPwdEnvVar ([pscredential] $ConnectionCredential). Given the input user password, set the MySQL pwd environment variable
-#########################################################################################################################################
-
-function Set-MySqlPwdEnvVar
-{
-    param
-    (
-        [pscredential] $ConnectionCredential
-    )
-    Trace-Message "setting mysqlpassword to: $($ConnectionCredential.GetNetworkCredential().Password)"
-    [System.Environment]::SetEnvironmentVariable("MySql_PWD","$($ConnectionCredential.GetNetworkCredential().Password)")
-}
-
-#########################################################################################################################################
-# Get-TargetResource ([string]$Ensure, [string]Name, [pscredential]$ConnectionCredential): given the database string and the user password
-# determine whether the MySQL database is installed and return the result
-#########################################################################################################################################
+$ErrorPath = Join-Path -Path "$env:Temp" -ChildPath "MySQLErrors.txt"
 
 function Get-TargetResource
 {
@@ -51,46 +8,84 @@ function Get-TargetResource
     param
     (
         [parameter(Mandatory = $true)]
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",
-
-        [parameter(Mandatory = $true)]
-        [string] $Name,
+        [ValidateNotNullOrEmpty()]
+        [string] $DatabaseName,
         
         [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
     )
     
-    $Ensure = "Absent"
-
-    Set-MySqlPwdEnvVar -ConnectionCredential $ConnectionCredential
-
-    #note: we don't want to check and throw an exception in the case where the current configuration is Absent, and the
-    # user calls into Test-DscConfiguration or Get-DscConfiguration. In those cases, we just want to return false but not
-    # throw an exception as that is the wrong user experience.
-    if ((Test-Path -Path $MySQLExePath))
+    if (Test-Path $ErrorPath)
     {
-        $result = `
-            &$MySQLExePath `
-            "--execute=SELECT IF(EXISTS (SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$Name'), 'Yes','No')" `
-                --user=root --silent
+        Remove-Item -Path $ErrorPath
+    }
+  
+    $arguments = "--execute=SELECT IF(EXISTS (SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$DatabaseName'), 'Yes','No')", `
+        "--user=root", "--password=$($RootCredential.GetNetworkCredential().Password)", "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+    $result = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
 
-        if($result -ieq  "Yes")
-        {
-            $Ensure = "Present"
-        }
+    Read-ErrorFile -ErrorFilePath $ErrorPath
+
+    if ($result -eq  "Yes")
+    {
+         $Ensure = "Present"
+    }
+    else
+    {
+        $Ensure = "Absent"
     }
 
     return @{
         Ensure = $Ensure
-        Name = $Name
+        DatabaseName = $DatabaseName
     }
 }
 
-#########################################################################################################################################
-# Test-TargetResource ([string]$Ensure, [string]Name, [pscredential]$ConnectionCredential): given the database string and the user password
-# determine whether the database is installed and return true or false based on the findings
-#########################################################################################################################################
+function Set-TargetResource 
+{
+    param
+    (
+        [ValidateSet("Present", "Absent")]
+        [string] $Ensure = "Present",
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $DatabaseName,
+        
+        [parameter(Mandatory = $true)]
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+)
+    
+    if (Test-Path $ErrorPath)
+    {
+        Remove-Item -Path $ErrorPath
+    }
+  
+    if($Ensure -eq "Present")
+    {
+        Write-Verbose "Creating Database $DatabaseName..."
+        $arguments = "--execute=CREATE DATABASE $DatabaseName", "--user=root", "--password=$($RootCredential.GetNetworkCredential().Password)", `
+            "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+        $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+    }
+    else
+    {
+        Write-Verbose "Dropping Database $DatabaseName..."
+        $arguments = "--execute=DROP DATABASE $DatabaseName", "--user=root", "--password=$($RootCredential.GetNetworkCredential().Password)", `
+            "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+        $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+    }
+
+    Read-ErrorFile -ErrorFilePath $ErrorPath
+}
 
 function Test-TargetResource 
 {
@@ -98,22 +93,26 @@ function Test-TargetResource
     [CmdletBinding(SupportsShouldProcess=$true)]
     param
     (
-        [parameter(Mandatory = $true)]
         [ValidateSet("Present", "Absent")]
         [string] $Ensure = "Present",
 
         [parameter(Mandatory = $true)]
-        [string] $Name,
+        [ValidateNotNullOrEmpty()]
+        [string] $DatabaseName,
         
         [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
     )
     
-    Trace-Message "Ensure is $Ensure"
+    Write-Verbose "Ensure is $Ensure"
 
-    $status = Get-TargetResource @psboundparameters
+    $status = Get-TargetResource -DatabaseName $DatabaseName -RootCredential $RootCredential -MySqlVersion $MySqlVersion
     
-    if($status.Ensure -eq $Ensure)
+    if($status['Ensure'] -eq $Ensure)
     {
         return $true
     }
@@ -122,49 +121,6 @@ function Test-TargetResource
         return $false
     }
 }
-
-#########################################################################################################################################
-# Set-TargetResource ([string]$Ensure, [string]Name, [pscredential]$ConnectionCredential): given the database string and the user password
-# either drop the database or create it, depending on Ensure value
-#########################################################################################################################################
-
-function Set-TargetResource 
-{
-    [CmdletBinding(SupportsShouldProcess=$true)]
-    param
-    (
-        [parameter(Mandatory = $true)]
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",
-
-        [parameter(Mandatory = $true)]
-        [string] $Name,
-        
-        [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential
-    )
-    
-    if((Test-TargetResource @psboundparameters))
-    {
-        return
-    }
-    
-    if($Ensure -eq "Present")
-    {
-        Trace-Message "Creating Database $Name..."
-        Set-MySqlPwdEnvVar -ConnectionCredential $ConnectionCredential
-
-        Trace-Message "$MySQLExePath --execute=create database $Name;  --user=root --silent"
-        $result = &"$MySQLExePath" "--execute=create database $Name;"  --user=root --silent
-    }
-    else
-    {
-        Trace-Message "Dropping Database $Name..."
-        Trace-Message "$env:ProgramFiles\mySql\Mysql Server 5.6\bin\mysqladmin.exe" -f drop $Name --user=root --silent
-        $result = &"$env:ProgramFiles\mySql\Mysql Server 5.6\bin\mysqladmin.exe" -f drop $Name --user=root --silent
-    }
-}
-
 
 Export-ModuleMember -function Get-TargetResource, Set-TargetResource, Test-TargetResource
 

--- a/DscResources/MSFT_xMySqlDatabase/MSFT_xMySqlDatabase.schema.mof
+++ b/DscResources/MSFT_xMySqlDatabase/MSFT_xMySqlDatabase.schema.mof
@@ -1,9 +1,10 @@
 [ClassVersion("1.0.0"),FriendlyName("xMySqlDatabase")] 
 class MSFT_xMySqlDatabase : OMI_BaseResource
 {
-    [Key, Description("Name of the database.")] String Name;
-    [Required, Description("Should the database be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Required, Description("The root credential that is used to install MySql server."), EmbeddedInstance("MSFT_Credential")] String ConnectionCredential;
+    [Key, Description("Name of the database.")] String DatabaseName;
+    [Write, Description("Should the database be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Required, Description("The root credential that is used to install MySql server."), EmbeddedInstance("MSFT_Credential")] String RootCredential;
+    [Required, Description("MYSql Version Number")] String MySqlVersion;
 };
 
 

--- a/DscResources/MSFT_xMySqlGrant/MSFT_xMySqlGrant.psm1
+++ b/DscResources/MSFT_xMySqlGrant/MSFT_xMySqlGrant.psm1
@@ -1,11 +1,4 @@
-#########################################################################################################################################
-# xMySqlGrant resource for granting user permission(s) to mySql database
-#########################################################################################################################################
-
-
-#constants
-$MySQLExePath = "$env:ProgramFiles\mySql\Mysql Server 5.6\bin\mysql.exe"
-
+# This module only supports a subset of the possible database privileges
 # A global variable that contains localized messages of MySqlGrant.
 data LocalizedData
 {
@@ -22,236 +15,166 @@ GrantDoesNotExist=A user with the name {0} does not exist.
 
 Import-LocalizedData LocalizedData -FileName MSFT_xMySqlGrant.strings.psd1
 
-#########################################################################################################################################
-# Set-MySqlPwdEnvironmentVariable ([pscredential] $RootPassword). Given the input root password, set the MySQL password environment variable
-#########################################################################################################################################
-
-function Set-MySqlPwdEnvironmentVariable
-{
-    param
-    (
-        [pscredential] $RootPassword
-    )
-    Write-Verbose "Setting MySql Server root password to: $($RootPassword.GetNetworkCredential().Password)"
-    [System.Environment]::SetEnvironmentVariable("MySql_PWD","$($RootPassword.GetNetworkCredential().Password)")
-}
-
-
-#########################################################################################################################################
-# Get-TargetResource ([string]$UserName, [string]DatabaseName, [string]Ensure, [string]ConnectionCredential, [string]$PermissionType) : given the username
-# determine what grants/permissions are given in which database and tables
-#########################################################################################################################################
+$ErrorPath = Join-Path -Path "$env:Temp" -ChildPath "MySQLErrors.txt"
 
 function Get-TargetResource
 {
     [OutputType([Hashtable])]
     param
     (
-       [parameter(Mandatory = $true)]
+        [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $UserName,
+        [string] $UserName,
 
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $DatabaseName = "*",
+        [string] $DatabaseName,
       
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",  
-       
         [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential,
+        [pscredential] $RootCredential,
 
-
+        [parameter(Mandatory = $true)]
         [ValidateSet("ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE")]
-        [string] $PermissionType = "ALL PRIVILEGES"
+        [ValidateNotNullOrEmpty()]
+        [string] $PermissionType,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
     )
     
-    $Ensure = "Absent"
-    $output = "$env:SystemDrive/ProgramData/MySQL/permissionlog.txt"      
-    $grant = $PermissionType
-    $grant+= "_priv"
-    Set-MySqlPwdEnvironmentVariable -RootPassword $ConnectionCredential 
-
-    if ((Test-Path -Path $MySQLExePath))
+    if (Test-Path $ErrorPath)
     {
-        # mysql does not have an individual flag for ALL, it stores it as set of all other flags such as create, drop, execute..
-        if ($PermissionType -ne "ALL PRIVILEGES" )
-        {
-            $result = &"$MySQLExePath" "--execute=select $grant from mysql.user where user = '$UserName' into outfile '$output';" --user=root --silent
+        Remove-Item -Path $ErrorPath
+    }
+  
+    $arguments = "--execute=SHOW GRANTS FOR '$UserName'@localhost", "--user=root", "--password=$($RootCredential.GetNetworkCredential().Password)", `
+        "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+    $results = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+    
+    Read-ErrorFile -ErrorFilePath $ErrorPath
 
-            $permission = Get-content $output
-            if ($permission -eq $null)
-             {
-                $msg = "$($LocalizedData.InvalidUserName) -f $UserName"
-                Write-Verbose -Message $msg
-             }
-            else
-             {
-                if($permission.Contains('Y'))
-                {
-                    $msg = "$($LocalizedData.GrantExists) -f $PermissionType for user $UserName"
-                    Write-Verbose -Message $msg
-                    $Ensure = "Present"
-                }
-                else
-                {
-                    $msg = "$($LocalizedData.GrantDoesNotExist) -f $PermissionType for user $UserName"
-                    Write-Verbose -Message $msg
-                }
-             }
-         }
-         else
-         {
-            #need to check every permission flag
-            $allFlags = "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE"
-            foreach( $flag in $allFlags)
+    $ensureResult = "Absent"
+
+    ForEach ($result in $results)
+    {
+        if ($result -match $DatabaseName)
+        {
+            if (($result -match $PermissionType) -or ($result -match "ALL PRIVILEGES"))
             {
-                $grant = $flag
-                $grant+= "_priv"
-                $result = &$MySQLExePath "--execute=select $grant from mysql.user where user = '$UserName' into outfile '$output';" --user=root --silent
-                $permission = Get-content $output
-                if(($permission -eq $null) -or ($permission.Contains('N')) )
-                {
-                    $Ensure = "Absent"
-                    $msg = "$($LocalizedData.GrantDoesNotExist) -f $flag for user $UserName"
-                    Write-Verbose -Message $msg                    
-                    break
-                }
-                else
-                {
-                    $Ensure = "Present"                    
-                    $msg = "$($LocalizedData.GrantExists) -f $flag for user $UserName"
-                    Write-Verbose -Message $msg 
-                    #mysql fails to save into a file that already exists so deleting it here
-                    Remove-Item -Path $output -Force -ErrorAction SilentlyContinue
-                }
-            
+                $ensureResult = "Present"
+                break
             }
-                            
-         }#end of all flags check
-        
-          Remove-Item -Path $output -Force -ErrorAction SilentlyContinue
+        }
     }
 
     return @{
-        UserName = $UserName
-        DatabaseName = $DatabaseName
-        Ensure = $Ensure
-        PermissionType = $PermissionType
+        UserName         = $UserName
+        DatabaseName     = $DatabaseName
+        Ensure           = $ensureResult
+        PermissionType   = $PermissionType
     }
 }
 
-#########################################################################################################################################
-# Test-TargetResource ([string]$UserName, [string]DatabaseName, [string]Ensure, [string]ConnectionCredential, [string]$PermissionType) : given the username: determine whether the given user name exists in mysql user list using the root password
-#########################################################################################################################################
-
-function Test-TargetResource 
+function Set-TargetResource 
 {
-    [OutputType([Boolean])]
-    [CmdletBinding(SupportsShouldProcess=$true)]
     param
     (
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $UserName,
+        [string] $UserName,
 
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $DatabaseName = "*",
+        [string] $DatabaseName,
       
         [ValidateSet("Present", "Absent")]
         [string] $Ensure = "Present",  
        
         [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential,
+        [pscredential] $RootCredential,
 
-
+        [parameter(Mandatory = $true)]
         [ValidateSet("ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE")]
-        [string] $PermissionType = "ALL PRIVILEGES"
+        [ValidateNotNullOrEmpty()]
+        [string] $PermissionType,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+    )
+    
+    if (Test-Path $ErrorPath)
+    {
+        Remove-Item -Path $ErrorPath
+    }
+  
+    if($Ensure -eq "Present")
+    {        
+        Write-Verbose "Granting $PermissionType on $DatabaseName to $UserName..."
+
+        $arguments = "--execute=GRANT $PermissionType ON $DatabaseName.* TO '$UserName'@localhost", "--user=root", `
+            "--password=$($RootCredential.GetNetworkCredential().Password)", "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+        $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+                   
+        $msg = "$($LocalizedData.GrantCreated) -f $UserName"
+    }
+    else
+    {        
+        Write-Verbose "Revoking $PermissionType on $DatabaseName to $UserName..."
+
+        $arguments = "--execute=REVOKE $PermissionType ON $DatabaseName.* FOR '$UserName'@localhost", "--user=root", `
+            "--password=$($RootCredential.GetNetworkCredential().Password)", "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+        $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+
+        $msg = "$($LocalizedData.GrantRemoved) -f $UserName"
+    }
+
+    Read-ErrorFile -ErrorFilePath $ErrorPath
+
+    Write-Verbose -Message $msg   
+}
+
+function Test-TargetResource 
+{
+    [OutputType([Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $UserName,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $DatabaseName,
+       
+        [ValidateSet("Present", "Absent")]
+        [string] $Ensure = "Present",  
+       
+        [parameter(Mandatory = $true)]
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateSet("ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE")]
+        [ValidateNotNullOrEmpty()]
+        [string] $PermissionType,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
     )
     
     Write-Verbose "Ensure is $Ensure"
 
-    $status = Get-TargetResource @psboundparameters
+    $status = Get-TargetResource -UserName $UserName -DatabaseName $DatabaseName -RootCredential $RootCredential -PermissionType $PermissionType -MySqlVersion $MySqlVersion
     
-    if($status.Ensure -eq $Ensure)
+    if($status['Ensure'] -eq $Ensure)
     {
         return $true
     }
     else
     {
         return $false
-    }
-}
-
-
-#########################################################################################################################################
-# Set-TargetResource ([string]$UserName, [string]DatabaseName, [string]Ensure, [string]ConnectionCredential, [string]$PermissionType) : given the username: Add the given user name to mysql user list using the root password
-#########################################################################################################################################
-
-
-function Set-TargetResource 
-{
-    [CmdletBinding(SupportsShouldProcess=$true)]
-    param
-    (
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $UserName,
-
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $DatabaseName = "*",
-      
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",  
-       
-        [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential,
-
-        
-        [ValidateSet("ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE")]
-        [string] $PermissionType = "ALL PRIVILEGES"
-    )
-    
-    if((Test-TargetResource @psboundparameters))
-    {
-        return
-    }
-            
-    Set-MySqlPwdEnvironmentVariable -RootPassword $ConnectionCredential 
-    $HostName = "localhost"
-
-    $SqlUser = "`'$UserName`'@"
-    $SqlUser+="`'$HostName`'"
-
-    if($Ensure -eq "Present")
-    {        
-        Write-Verbose "$MySQLExePath grant $PermissionType on $DatabaseName.* To $SqlUser;  --user=root --silent"
-                   
-        $result = &"$MySQLExePath" "--execute=grant $PermissionType on $DatabaseName.* To $SqlUser;" --user=root --silent
-
-        $serialize = &"$MySQLExePath" "--execute=FLUSH PRIVILEGES;"  --user=root --silent
-
-        $msg = "$($LocalizedData.GrantCreated) -f $UserName"
-        Write-Verbose -Message $msg         
-    }
-    else
-    {        
-        Write-Verbose "$MySQLExePath revoke $PermissionType on $DatabaseName.* from $SqlUser --user=root --silent"
-
-        $result = &"$MySQLExePath" "--execute=revoke $PermissionType on $DatabaseName.* from $SqlUser;" --user=root --silent
-        #save the changes into mysql
-        $serialize = &"$MySQLExePath" "--execute=FLUSH PRIVILEGES;" --user=root --silent
-
-        $msg = "$($LocalizedData.GrantRemoved) -f $UserName"
-        Write-Verbose -Message $msg   
     }
 }
 

--- a/DscResources/MSFT_xMySqlGrant/MSFT_xMySqlGrant.schema.mof
+++ b/DscResources/MSFT_xMySqlGrant/MSFT_xMySqlGrant.schema.mof
@@ -2,12 +2,12 @@
 [ClassVersion("1.0.0"),FriendlyName("xMySqlGrant")] 
 class MSFT_xMySqlGrant : OMI_BaseResource
 { 
-  [Key, Description("Name of MySQL user.")] String UserName;
-  [Key, Description("MySql database name to grant permissions.")] String DatabaseName;
-  [Required, Description("MySql connection credential used for the root."), EmbeddedInstance("MSFT_Credential")] String ConnectionCredential;
-  [Write, Description("MySql user permission type."), ValueMap{"ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE"}, Values{"ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE"}] String PermissionType;
-  [Write, Description("Ensure given grant to mySql database present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-
+    [Key, Description("Name of MySQL user.")] String UserName;
+    [Key, Description("MySql database name to grant permissions.")] String DatabaseName;
+    [Required, Description("MySql connection credential used for the root."), EmbeddedInstance("MSFT_Credential")] String RootCredential;
+    [Key, Description("MySql user permission type."), ValueMap{"ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE"}, Values{"ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE"}] String PermissionType;
+    [Write, Description("Ensure given grant to mySql database present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Required, Description("MYSql Version Number")] String MySqlVersion;
 };
 
 

--- a/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.psm1
+++ b/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.psm1
@@ -97,7 +97,7 @@ function Test-TargetResource
 
     $status = Get-TargetResource -MySqlVersion $MySqlVersion -RootPassword $RootPassword
 
-	# don't yet check if the root password matches
+    # don't yet check if the root password matches
     if(($status['Ensure'] -eq $Ensure) -and ($status['Port'] -eq $Port))
     {
         return $true

--- a/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.psm1
+++ b/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.psm1
@@ -1,123 +1,4 @@
-<#
-   DSC resource designed to create an instance of MySQL, using the supplied parameters as per resource schema.
-
-   Copyright (c) Microsoft Corporation, 2014
-#>
-
 # NOTE: LocalizedData isn't used in this resource as there are no interactive/user visible strings
-
-$mySqlVersion = "5.6"
-$Debug = $true
-
-################################################################################################################################
-# Trace-Message (write verbose if Debug flag is on)
-################################################################################################################################
-
-Function Trace-Message
-{
-    param([string] $Message)
-
-    if($Debug)
-    {
-        Write-Verbose $Message
-    }
-}
-
-
-#region MySql Helpers
-################################################################################################################################
-# Get-MySqlInstallerFolder (helper to get localtion of MySql installer folder on local machine)
-################################################################################################################################
-
-function Get-MySqlInstallerFolder
-{
-    if($env:PROCESSOR_ARCHITECTURE -eq "AMD64")
-    {
-        return "$(${env:ProgramFiles(x86)})\MySQL\MySQL Installer"
-    }
-    else
-    {
-        return "$(${env:ProgramFiles})\MySQL\MySQL Installer"
-    }
-}
-
-$mySqlInstallerConsole = Join-path (Get-MySqlInstallerFolder) -ChildPath "MySQLInstallerConsole.exe"
-
-################################################################################################################################
-# Get-MySqlInstalledComponents (helper to get SQL installed components)
-################################################################################################################################
-
-function Get-MySqlInstalledComponents
-{
-    # we don't want to throw an exception here for the case where Ensure=Absent during Test/Get-DscConfiguration. Instead of failing
-    # with an exception it should return false. Removing exception handling and throwing.
-    if ((Test-Path -Path $mySqlInstallerConsole))
-    {
-        $statusResults = &$mySqlInstallerConsole --nowait --type=server --action=Status
-
-        $statusResults | % {
-        
-            # split each line on the status delimiter
-            $statusPair = $_ -split ":"
-
-            # if the line contains a status, check the status
-            if($statusPair.count -gt 1) {
-
-                # if the status is installed return the product name
-                if($statusPair[1].Trim() -ieq "installed.")
-                {
-                    Write-Output $statusPair[0].Trim()
-                }
-            }
-        }
-    }
-    else
-    {
-        $null
-    }
-}
-
-################################################################################################################################
-# Get-MySqlArchitectureName (helper to get SQL architecture string in expected format)
-################################################################################################################################
-
-function Get-MySqlArchitectureName
-{
-    if($env:PROCESSOR_ARCHITECTURE -eq "AMD64")
-    {
-        return "winx64"
-    }
-    else
-    {
-        return "win32"
-    }
-}
-
-################################################################################################################################
-# Get-MySqlProductName (helper to get product name of MySQL)
-################################################################################################################################
-
-function Get-MySqlProductName
-{
-    return "mysql-server-$mySqlVersion-$(Get-MySqlArchitectureName)"
-}
-
-################################################################################################################################
-# Get-MySqlCatalogName (helper to get the MySQL catalog name)
-################################################################################################################################
-
-function Get-MySqlCatalogName
-{
-    return "mysql-$mySqlVersion-$(Get-MySqlArchitectureName)"
-}
-
-#endregion
-
-#region *-TargetResource implementation
-
-################################################################################################################################
-# Get-TargetResource (params: ServiceName, Ensure, RootPassword)
-################################################################################################################################
 
 function Get-TargetResource
 {
@@ -125,73 +6,99 @@ function Get-TargetResource
     param
     (
         [parameter(Mandatory = $true)]
-        [string] $ServiceName,
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion,
         
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",
-
         [parameter(Mandatory = $true)]
         [pscredential] $RootPassword
     )
     
-    $Ensure = "Absent"
-    $MySqlInstalled = $false 
+    $MySqlInstalled = (Get-MySqlVersionInstalled -MySqlVersion $MySqlVersion)
 
-    # get installed products
-    $products = @(Get-MySqlInstalledComponents)
-
-    if ($products -ne $null)
+    if ($MySqlInstalled)
     {
-        foreach($product in $products)
-        {
-            Trace-Message  "'$product' is currently installed"
-        }
-    
-        Trace-Message "Checking to see if installed products contains '$((Get-MySqlProductName))'"
-
-        if($products -contains (Get-MySqlProductName))
-        {
-            $MySqlInstalled  = $true 
-        }
-
-        if($MySqlInstalled )
-        {
-            Trace-Message "Present"
-            $Ensure = "Present"
-        }
+        $ensureResult = "Present"
+        $portResult = (Get-MySqlPort -MySqlVersion $MySqlVersion)
+    }
+    else
+    {
+        $ensureResult = "Absent"
+        $portResult = $null
     }
 
     return @{
-        Ensure = $Ensure
-        ServiceName = $ServiceName
+        Ensure       = $ensureResult
+        MySqlVersion = $MySqlVersion
+        Port         = $portResult
     }
 }
 
-################################################################################################################################
-# Test-TargetResource (params: ServiceName, Ensure, RootPassword)
-################################################################################################################################
+function Set-TargetResource 
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion,
+
+        [ValidateSet("Present", "Absent")]
+        [string] $Ensure = "Present",
+
+        [parameter(Mandatory = $true)]
+        [pscredential] $RootPassword,
+
+        [string] $Port = "3306"
+        
+    )
+    
+    if ($Ensure -eq "Present")
+    {
+        $versionsInstalled = Get-MySqlAllInstalled
+
+        if ($versionsInstalled -eq $null)
+        {
+            Write-Verbose "Installing MySQL..."
+            $arguments = "community", "install", `
+                "server;$MySqlVersion;$(Get-ArchitectureName):*:servertype=Server;port=$Port;passwd=$($RootPassword.GetNetworkCredential().Password)", "-silent"
+            $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlInstallerConsole) -Arguments $arguments
+        }
+        else
+        {
+            Write-Verbose "Updating/Upgrading is not currently implemented"
+        }
+    }
+    else
+    {
+        Write-Verbose "Uninstall is not currently implemented"
+    }
+
+}
 
 function Test-TargetResource 
 {
     [OutputType([Boolean])]
-    [CmdletBinding(SupportsShouldProcess=$true)]
     param
     (
         [parameter(Mandatory = $true)]
-        [string] $ServiceName,
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion,
         
         [ValidateSet("Present", "Absent")]
         [string] $Ensure = "Present",
         
         [parameter(Mandatory = $true)]
-        [pscredential] $RootPassword
+        [pscredential] $RootPassword,
+
+        [string] $Port = "3306"
+
     )
     
-    Trace-Message "Ensure is $Ensure"
+    Write-Verbose "Ensure is $Ensure"
 
-    $status = Get-TargetResource @psboundparameters
+    $status = Get-TargetResource -MySqlVersion $MySqlVersion -RootPassword $RootPassword
 
-    if($status.Ensure -eq $Ensure)
+	# don't yet check if the root password matches
+    if(($status['Ensure'] -eq $Ensure) -and ($status['Port'] -eq $Port))
     {
         return $true
     }
@@ -200,104 +107,6 @@ function Test-TargetResource
         return $false
     }
 }
-
-################################################################################################################################
-# Set-TargetResource (params: ServiceName, Ensure, RootPassword)
-################################################################################################################################
-
-function Set-TargetResource 
-{
-    [CmdletBinding(SupportsShouldProcess=$true)]
-    param
-    (
-        [parameter(Mandatory = $true)]
-        [string] $ServiceName,
-
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",
-
-        [parameter(Mandatory = $true)]
-        [pscredential] $RootPassword
-        
-    )
-    
-    if((Test-TargetResource @psboundparameters))
-    {
-        return
-    }
-    
-    $status = Get-TargetResource @psboundparameters 
-
-   <# config parameters:
-      servertype     - Config type [developer|server|dedicated] Default developer.
-      enabletcpip    - Use TCP/IP. Possible values [true | false] Default true.
-      port           - Port MySQL Server will use for communication. Default 3306
-      openfirewall   - Create a rule in the Windows firewall for the specified port.
-      passwd         - The default root password. Required.
-      existingpasswd - Existing instances require the current password.
-      servicename    - The Service Name. Default MySQL56
-      sauser         - A valid username.
-      sapass         - The password for sauser.
-      autostart      - Autmatically start the service at system startup? Default true.
-      generallog     - Enable General Log [true|false]. Default false
-      generallogname - General Log path/filename. Default MGMT-9737-3172.log
-      slowlog        - Enable Slow Query Log [true|false] Default false
-      slowlogname    - Slow Query Log path/filename. Default MGMT-9737-3172-slow.log
-      slowtime       - Time threshold for slow query log in seconds. Default 10
-      binlog         - Enable Bin Log [true|false] Default false
-      binlogname     - Bin Log path/filename base. Default MGMT-9737-3172-bin
-      errorlogname   - Error Log path/filename. Default. MGMT-9737-3172.err
-      removedatadir  - [true|false]. Default false. Only valid for remove action.
-      timeout  - Configuration timeout in seconds. The default is 180.
-      #>
-
-    # NOTE: BUGBUG: the reason we need to do this is as follows:
-    # The first time a node gets configured with the sql instance, there is no trace of it 
-    # on the machine, which changes the way in which we construct the config parameter. If it is
-    # the first time, the 'existingpasswd' argument cannot be given or it will fail. Once installed
-    # the installation creates a datadir that does not get remove during uninstall. After that, every
-    # time we try to install with the config, we have to provide the existingpasswd parameter, or installation/removal
-    # will fail. This is an issue with the usage of removedatadir parameter, and this is the work-around
-
-    $InstanceFlagpath = "$($env:ProgramFiles)\WindowsPowerShell\Modules\xMySQL\MySQLInstanceFlag.txt"
-    Trace-Message "SQL instance flag path is $InstanceFlagpath"
-
-    if (!(Test-Path -Path $InstanceFlagpath))
-    {
-        # this is the first time this is installed the machine (if Ensure=Present) and we cannot specify the existing pwd or it will fail
-        Trace-Message "Instance flag not found. Omitting existing password parameter"
-        $config = "--config=$(Get-MySqlProductName):passwd=$($RootPassword.GetNetworkCredential().Password);servicename=$ServiceName;autostartservice=true;servertype=server"
-    }
-    else
-    {
-        # in this case, we found the instance flag marker so we know that we need to specify the existingpwd argument.
-        Trace-Message "Instance flag was found. Using optional parameter existingpasswd"
-        $config = "--config=$(Get-MySqlProductName):passwd=$($RootPassword.GetNetworkCredential().Password);servicename=$ServiceName;existingpasswd=$($RootPassword.GetNetworkCredential().Password);autostartservice=true;servertype=server"
-    }
-    
-    Trace-Message "mySqlInstallerConsole is $mySqlInstallerConsole"
-
-    if($Ensure -eq "Present")
-    {
-        if(-not $status.MySqlInstalled)
-        {
-            Trace-Message "Installing MySQL"
-            &$mySqlInstallerConsole --nowait --action=Install "--catalog=$(Get-MySqlCatalogName)" "--product=$(Get-MySqlProductName)" $config
-
-            # don't stamp the machine until after the installation has completed, successfully!
-            Trace-Message "Creating instance flag"
-            New-Item -ItemType File -Path $InstanceFlagpath -Force
-            Trace-Message "Instance flag has been created"
-        }
-    }
-    else
-    {
-        Trace-Message "Removing MySQL"
-        &$mySqlInstallerConsole --nowait --type=server --action=Remove $config
-    }
-
-}
-#endregion
 
 Export-ModuleMember -function Get-TargetResource, Set-TargetResource, Test-TargetResource
 

--- a/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.schema.mof
+++ b/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.schema.mof
@@ -2,19 +2,10 @@
 [ClassVersion("1.0.0"),FriendlyName("xMySqlServer")] 
 class MSFT_xMySqlServer : OMI_BaseResource
 {
-  [Key, Description("Provides the service name to use during setup of MySQL")]
-  String ServiceName;
-  
-  [Write,
-  ValueMap{"Present", "Absent"},Values{"Present", "Absent"},
-  Description("Ensure resource is present or absent")]
-  String Ensure;
-  
-  [required,
-  Write,
-  EmbeddedInstance("MSFT_Credential"),
-  Description("The root credential that is used to install mySql server.")]
-  String RootPassword;
+    [Key, Description("mySql Version Number")] String MySqlVersion;
+    [Write, ValueMap{"Present", "Absent"},Values{"Present", "Absent"}, Description("Ensure server is present or absent")] String Ensure;
+    [Required, EmbeddedInstance("MSFT_Credential"), Description("The root credential that is used to install mySql server.")] String RootPassword;
+    [Write, Description("The port number for the service")] String Port;
 };
 
 

--- a/DscResources/MSFT_xMySqlUser/MSFT_xMySqlUser.psm1
+++ b/DscResources/MSFT_xMySqlUser/MSFT_xMySqlUser.psm1
@@ -1,11 +1,3 @@
-#########################################################################################################################################
-# xMySqlUSer module for creating/removing users from MySql Server
-#########################################################################################################################################
-
-
-#constants
-$MySQLExePath = "$env:ProgramFiles\mySql\Mysql Server 5.6\bin\mysql.exe"
-
 # A global variable that contains localized messages of MySqlUser.
 data LocalizedData
 {
@@ -13,7 +5,6 @@ data LocalizedData
 ConvertFrom-StringData @'
 UserCreated=User {0} created successfully.
 UserRemoved=User {0} removed successfully.
-InvalidUserName=The name {0} cannot be used. Names may not consist entirely of periods and/or spaces, or contain these characters: {1}
 UserExists=A user with the name {0} exists.
 UserDoesNotExist=A user with the name {0} does not exist.
 '@
@@ -21,25 +12,7 @@ UserDoesNotExist=A user with the name {0} does not exist.
 
 Import-LocalizedData LocalizedData -FileName MSFT_xMySqlUser.strings.psd1
 
-#########################################################################################################################################
-# Set-MySqlPwdEnvVar ([pscredential] $RootPassword). Given the input root password, set the MySQL password environment variable
-#########################################################################################################################################
-
-function Set-MySqlPwdEnvironmentVariable
-{
-    param
-    (
-        [pscredential] $RootPassword
-    )
-    Write-Verbose "Setting MySql Server root password to: $($RootPassword.GetNetworkCredential().Password)"
-    [System.Environment]::SetEnvironmentVariable("MySql_PWD","$($RootPassword.GetNetworkCredential().Password)")
-}
-
-
-#########################################################################################################################################
-# Get-TargetResource ([string]$Name, [string]Ensure, [string]Credential, [string]ConnectionCredential) : given the username
-# determine whether the user exists in MySQL database and return the result
-#########################################################################################################################################
+$ErrorPath = Join-Path -Path "$env:Temp" -ChildPath "MySQLErrors.txt"
 
 function Get-TargetResource
 {
@@ -48,80 +21,124 @@ function Get-TargetResource
     (
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $Name,
+        [string] $UserName,
       
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",
-       
         [parameter(Mandatory = $true)]
-        [pscredential] $Credential,
+        [pscredential] $UserCredential,
 
         [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential       
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion    
     )
     
-    $Ensure = "Absent"
-
-    ValidateUserName -UserName $Name   
-
-    Set-MySqlPwdEnvironmentVariable -RootPassword $ConnectionCredential
-
-    if ((Test-Path -Path $MySQLExePath))
+    if (Test-Path $ErrorPath)
     {
-        $result = `
-            &$MySQLExePath `
-            "--execute=SELECT IF(EXISTS (SELECT USER FROM MYSQL.USER  WHERE USER = '$Name'), 'Yes','No')" `
-                --user=root --silent
+        Remove-Item -Path $ErrorPath
+    }
 
-        if($result -ieq  "Yes")
-        {
-             $msg = "$($LocalizedData.UserExists) -f $Name"
-             Write-Verbose -Message $msg          
-             $Ensure = "Present"
-        }
-        else
-        {
-           $msg = "$($LocalizedData.UserDoesNotExist) -f $Name"
-           Write-Verbose -Message $msg          
-        }
+    $arguments = "--execute=SELECT IF(EXISTS (SELECT USER FROM MYSQL.USER WHERE USER = '$UserName' AND HOST = 'localhost'), 'Yes','No')", "--user=root", `
+        "--password=$($RootCredential.GetNetworkCredential().Password)", "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+    $result = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+
+    Read-ErrorFile -ErrorFilePath $ErrorPath
+
+    if($result -ieq  "Yes")
+    {
+        $msg = "$($LocalizedData.UserExists) -f $UserName"
+        Write-Verbose -Message $msg          
+        $ensureResult = "Present"
+    }
+    else
+    {
+        $msg = "$($LocalizedData.UserDoesNotExist) -f $UserName"
+        Write-Verbose -Message $msg          
+        $ensureResult = "Absent"
     }
 
     return @{
-        Name = $Name
-        Ensure = $Ensure
-        
+        UserName = $UserName
+        Ensure = $ensureResult
     }
 }
 
-#########################################################################################################################################
-# Test-TargetResource ([string]$Name, [string]Ensure, [pscredential]$Credential, [pscredential]$ConnectionCredential): determine whether the given user name exists in mysql user list using the root password
-#########################################################################################################################################
-
-function Test-TargetResource 
+function Set-TargetResource 
 {
-    [OutputType([Boolean])]
-    [CmdletBinding(SupportsShouldProcess=$true)]
     param
     (
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $Name,
+        [string] $UserName,
+
+        [ValidateSet("Present", "Absent")]
+        [string] $Ensure = "Present",
+        
+        [parameter(Mandatory = $true)]
+        [pscredential] $UserCredential,
+
+        [parameter(Mandatory = $true)]
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+    )
+    
+    if (Test-Path $ErrorPath)
+    {
+        Remove-Item -Path $ErrorPath
+    }
+
+    if($Ensure -eq "Present")
+    {        
+        Write-Verbose -Message "Adding user $UserName..."           
+        $arguments = "--execute=CREATE USER '$UserName'@'localhost' IDENTIFIED BY '$($UserCredential.GetNetworkCredential().Password)'", "--user=root", `
+            "--password=$($RootCredential.GetNetworkCredential().Password)", "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+        $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+        $msg = "$($LocalizedData.UserCreated) -f $UserName"
+        Write-Verbose -Message $msg       
+    }
+    else
+    {        
+        Write-Verbose "Dropping user $UserName..."
+        $arguments = "--execute=DROP USER '$UserName'@'localhost'", "--user=root", "--password=$($RootCredential.GetNetworkCredential().Password)", `
+            "--port=$(Get-MySqlPort -MySqlVersion $MySqlVersion)", "--silent"
+        $null = Invoke-MySqlCommand -CommandPath $(Get-MySqlExe -MySqlVersion $MySqlVersion) -Arguments $arguments 2>$ErrorPath
+        $msg = "$($LocalizedData.UserRemoved) -f $UserName"
+        Write-Verbose -Message $msg  
+    }
+
+    Read-ErrorFile -ErrorFilePath $ErrorPath
+}
+
+function Test-TargetResource 
+{
+    [OutputType([Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $UserName,
       
         [ValidateSet("Present", "Absent")]
         [string] $Ensure = "Present",
        
         [parameter(Mandatory = $true)]
-        [pscredential] $Credential,
+        [pscredential] $UserCredential,
 
         [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential
+        [pscredential] $RootCredential,
+
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
     )
     
     Write-Verbose "Ensure is $Ensure"
 
-    $status = Get-TargetResource @psboundparameters
+    $status = Get-TargetResource -UserName $UserName -UserCredential $UserCredential -RootCredential $RootCredential -MySqlVersion $MySqlVersion
     
     if($status.Ensure -eq $Ensure)
     {
@@ -131,146 +148,6 @@ function Test-TargetResource
     {
         return $false
     }
-}
-
-
-#########################################################################################################################################
-# Set-TargetResource ([string]$Name, [string]Ensure, [pscredential]$Credential, [pscredential]$ConnectionCredential): Add the given user name to mysql user list using the root password
-#########################################################################################################################################
-
-
-function Set-TargetResource 
-{
-    [CmdletBinding(SupportsShouldProcess=$true)]
-    param
-    (
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $Name,
-
-        [ValidateSet("Present", "Absent")]
-        [string] $Ensure = "Present",
-        
-        [parameter(Mandatory = $true)]
-        [pscredential] $Credential,
-
-        [parameter(Mandatory = $true)]
-        [pscredential] $ConnectionCredential
-       
-    )
-    
-    if((Test-TargetResource @psboundparameters))
-    {
-        return
-    }
-    
-    Set-MySqlPwdEnvironmentVariable -RootPassword $ConnectionCredential 
-    $HostName = "localhost"
-    $SqlUser = "`'$Name`'@"
-    $SqlUser+="`'$HostName`'"
-
-    if($Ensure -eq "Present")
-    {        
-        $psw = "$($Credential.GetNetworkCredential().Password)"
-        Write-Verbose "$MySQLExePath create user $SqlUser identified by $psw;  --user=root --silent"
-                   
-        $result = &"$MySQLExePath" "--execute=create user $SqlUser identified by `'$psw`'"  --user=root --silent
-        $msg = "$($LocalizedData.UserCreated) -f $Name"
-        Write-Verbose -Message $msg       
-    }
-    else
-    {        
-        Write-Verbose "$MySQLExePath drop $SqlUser --user=root --silent"
-        $result = &"$MySQLExePath" "--execute=DROP user $SqlUser"  --user=root --silent
-
-        $msg = "$($LocalizedData.UserRemoved) -f $Name"
-        Write-Verbose -Message $msg  
-    }
-}
-
-#########################################################################################################################################
-# Throw-InvalidDataException ([string]$errorId, [string]$errorMessage): generate an error record and throw given the input parameters
-#########################################################################################################################################
-
-function Throw-InvalidDataException
-{
-    param(
-        [parameter(Mandatory = $true)]
-        [System.String] 
-        $errorId,
-        [parameter(Mandatory = $true)]
-        [System.String]
-        $errorMessage
-    )
-    
-    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidData
-    $exception = New-Object System.InvalidOperationException $errorMessage 
-    $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null
-    throw $errorRecord
-}
-
-#########################################################################################################################################
-# Validates the User name for invalid charecters.
-#########################################################################################################################################
-function ValidateUserName
-{
-    param
-    (
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $UserName
-    )
-
-    # Check if the name consists of only periods and/or white spaces.
-    $wrongName = $true;
-    for($i = 0; $i -lt $UserName.Length; $i++)
-    {
-        if(-not [Char]::IsWhiteSpace($UserName, $i) -and $UserName[$i] -ne '.')
-        {
-            $wrongName = $false;
-            break;
-        }
-    }
-
-    $invalidChars = @('\','/','"','[',']',':','|','<','>','+','=',';',',','?','*','@')
-
-    if($wrongName)
-    {
-        ThrowInvalidArgumentError -ErrorId "UserNameHasOnlyWhiteSpacesAndDots" -ErrorMessage ($LocalizedData.InvalidUserName -f $UserName, [string]::Join(" ", $invalidChars))
-    }
-
-    if($UserName.IndexOfAny($invalidChars) -ne -1)
-    {
-        ThrowInvalidArgumentError -ErrorId "UserNameHasInvalidCharachter" -ErrorMessage ($LocalizedData.InvalidUserName -f $UserName, [string]::Join(" ", $invalidChars))
-    }
-}
-
-#########################################################################################################################################
-# Throws an argument error.
-#########################################################################################################################################
-function ThrowInvalidArgumentError
-{
-    [CmdletBinding()]
-    param
-    (
-        
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorId,
-
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorMessage
-    )
-
-    $errorCategory=[System.Management.Automation.ErrorCategory]::InvalidArgument
-    $exception = New-Object System.ArgumentException $ErrorMessage;
-    $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $ErrorId, $errorCategory, $null
-    throw $errorRecord
 }
 
 Export-ModuleMember -function Get-TargetResource, Set-TargetResource, Test-TargetResource

--- a/DscResources/MSFT_xMySqlUser/MSFT_xMySqlUser.schema.mof
+++ b/DscResources/MSFT_xMySqlUser/MSFT_xMySqlUser.schema.mof
@@ -2,11 +2,11 @@
 [ClassVersion("1.0.0"),FriendlyName("xMySqlUser")] 
 class MSFT_xMySqlUser : OMI_BaseResource
 { 
-  [Key, Description("Name of MySQL user to create or remove.")] String Name;
-  [Required, Description("Credential for MySql user."), EmbeddedInstance("MSFT_Credential")] String Credential;
-  [Required, Description("MySql connection credential used to create a user."), EmbeddedInstance("MSFT_Credential")] String ConnectionCredential;
-  [Write, Description("Ensure mysql user is present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-
+    [Key, Description("Name of MySQL user to create or remove.")] String UserName;
+    [Required, Description("Credential for MySQL user."), EmbeddedInstance("MSFT_Credential")] String UserCredential;
+    [Required, Description("MySQL root credential used to create a user."), EmbeddedInstance("MSFT_Credential")] String RootCredential;
+    [Write, Description("Ensure MySQL user is present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Required, Description("MySQL Version Number")] String MySqlVersion;
 };
 
 

--- a/MSFT_xMySqlUtilities.psm1
+++ b/MSFT_xMySqlUtilities.psm1
@@ -1,0 +1,315 @@
+function Invoke-MySqlCommand
+{
+    <#
+    .SYNOPSIS
+        This function runs the given command with the given arguments.  This
+        is done so that the function can be mocked for unit testing.
+
+    .EXAMPLE
+        Invoke-MySqlCommand -CommandPath "C:\somepath.exe" -Arguments "test", "test2"
+
+    .PARAMETER CommandPath
+        This is the path to the command you want to run.
+
+    .PARAMETER Arguments
+        These are the arguments you want to supply to the command.
+    #>
+
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $CommandPath,
+
+        [parameter(Mandatory = $true)]
+        [string[]] $Arguments
+    )
+
+    if (Test-Path -Path $CommandPath)
+    {
+        & $CommandPath $Arguments
+    }
+    else
+    {
+        Throw "$CommandPath does not exist"
+    }
+}
+
+function Get-MySqlInstallerConsole
+{
+    <#
+    .SYNOPSIS
+        This function returns the path for the MySQL Installer Console.
+
+    .EXAMPLE
+        Get-MySqlInstallerConsole
+        C:\Program Files (x86)\MySQL\MySQL Installer for Windows\MySQLInstallerConsole.exe
+    #>
+
+    $mySqlInstallerConsole = Join-Path -Path "$(${env:ProgramFiles(x86)})\MySQL\MySQL Installer for Windows" -ChildPath "MySQLInstallerConsole.exe"
+
+    # Throw an exception if MySQL Installer for Windows isn't installed
+    if (-not (Test-Path -Path $mySqlInstallerConsole))
+    {
+        Throw 'Please ensure that MySQL Installer for Windows is installed'
+    }
+
+    return $mySqlInstallerConsole
+}
+
+function Get-MySqlExe
+{
+    <#
+    .SYNOPSIS
+        This function takes in a version number and returns the path of
+        mysql.exe for that version.  It checks to see if the x64
+        version is installed and then if the x86 version is
+        installed.  If neither is installed it throws an error.
+
+    .EXAMPLE
+        Get-MySqlExe -MySqlVersion "5.6.17"
+        C:\Program Files\MySQL\MySQL Server 5.6\bin\mysql.exe
+
+    .EXAMPLE
+        Get-MySqlExe -MySqlVersion "5.6.17"
+        C:\Program Files (x86)\MySQL\MySQL Server 5.6\bin\mysql.exe
+
+    .PARAMETER MySqlVersion
+        The version of MySQL you want the mysql.exe path for.
+    #>
+
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+    )
+
+    $shortVersion = Get-ShortVersion -MySqlVersion $MySqlVersion
+    $mySqlExeX64 = Join-Path -Path "$(${env:ProgramFiles})\MySQL\MySQL Server $shortVersion\bin" -ChildPath "mysql.exe"
+    $mySqlExeX86 = Join-Path -Path "$(${env:ProgramFiles(x86)})\MySQL\MySQL Server $shortVersion\bin" -ChildPath "mysql.exe"
+
+    # Throw an exception if the path doesn't exist
+    if (Test-Path -Path $mySqlExeX64)
+    {
+        return $mySqlExeX64
+    }
+    elseif (Test-Path -Path $mySqlExeX86)
+    {
+        return $mySqlExeX86
+    }
+    else
+    {
+        Throw "Please ensure that MySQL Version $shortVersion is installed"
+    }
+}
+
+function Get-MySqlVersionInstalled
+{
+    <#
+    .SYNOPSIS
+        This function takes in a version number and determines if that
+        version of MySQL is installed.
+
+    .EXAMPLE
+        Get-MySqlVersionInstalled -MySqlVersion "5.6.17"
+        True
+
+    .EXAMPLE
+        Get-MySqlVersionInstalled -MySqlVersion "5.6.17"
+        False
+
+    .PARAMETER MySqlVersion
+        The MySQL version you want to know about.
+    #>
+
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+    )
+
+    $MySqlInstalled  = $false
+    $arguments = "community", "status"
+
+    $statusResults = (Invoke-MySqlCommand -CommandPath $(Get-MySqlInstallerConsole) -Arguments $arguments) -split "`r`n"
+ 
+    ForEach ($statusResult in $statusResults)
+    {
+        if ($statusResult -eq "MySQL Server $MySqlVersion")
+        {
+           $MySqlInstalled  = $true 
+        }
+    }
+
+    return $MySqlInstalled
+}
+
+function Get-MySqlAllInstalled
+{
+    <#
+    .SYNOPSIS
+        This function returns all of the versions of MySQL
+        that are installed.
+
+    .EXAMPLE
+        Get-MySqlAllInstalled
+        5.6.17
+        5.7.8
+
+    .EXAMPLE
+        Get-MySqlAllInstalled
+        5.6.17
+    #>
+
+    $allVersionsInstalled = @()
+    $arguments = "community", "status"
+
+    $statusResults = (Invoke-MySqlCommand -CommandPath $(Get-MySqlInstallerConsole) -Arguments $arguments) -split "`r`n"
+
+    ForEach ($statusResult in $statusResults)
+    {
+        if ($statusResult -match "^MySQL Server")
+        {
+            # get the version number from the $statusResult
+            $splitStatus = $statusResult.Split(" ")
+            $allVersionsInstalled += ,$splitStatus[2]
+        }
+    }
+
+    return $allVersionsInstalled
+}
+
+function Get-ShortVersion
+{
+    <#
+    .SYNOPSIS
+        This function takes in a version number and returns the shortened
+        version of it.
+
+    .EXAMPLE
+        Get-ShortVersion -MySqlVersion "5.6.17"
+        5.6
+
+    .EXAMPLE
+        Get-ShortVersion -MySqlVersion "5.7.8"
+        5.7
+
+    .PARAMETER MySqlVersion
+        This is the long version number that you want shortened.
+    #>
+
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+    )
+
+    $splitVersion = $MySqlVersion.Split(".")
+    $shortVersion = [string]::Join(".",$splitVersion,0,2)
+    
+    return $shortVersion
+}
+
+function Read-ErrorFile
+{
+    <#
+    .SYNOPSIS
+        This function reads an error file and throws an error if there
+        is a line that starts off with ERROR.
+
+    .EXAMPLE
+        Read-ErrorFile -ErrorFilePath "C:\errorfile.txt"
+
+    .PARAMETER ErrorFilePath
+        This is the path of the error file you want read.
+    #>
+
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $ErrorFilePath
+    )
+
+    if (Test-Path -Path $ErrorFilePath)
+    {
+        ForEach ($line in (Get-Content $ErrorFilePath))
+        {
+            if ($line -match "^ERROR")
+            {
+                Remove-Item -Path $ErrorFilePath
+                Throw "$line"
+            }
+        }
+        Remove-Item -Path $ErrorFilePath
+    }
+}
+
+function Get-MySqlPort
+{
+    <#
+    .SYNOPSIS
+        This function looks at the my.ini file of the version passed in
+        and returns the port number from the file.
+
+    .EXAMPLE
+        Get-MySqlPort -MySqlVersion "5.6.17"
+        3306
+
+    .PARAMETER MySqlVersion
+        This is the version you want the port number for.
+    #>
+
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MySqlVersion
+    )
+
+    $myIniLocation = Join-Path "$(${env:ProgramData})\MySQL\MySQL Server $(Get-ShortVersion $MySqlVersion)" -ChildPath "my.ini"
+
+    # Throw an exception if $myIniLocation doesn't exist
+    if (-not (Test-Path -Path $myIniLocation))
+    {
+        Throw 'The my.ini file does not exist in the standard location'
+    }
+
+    ForEach ($line in (Get-Content $myIniLocation))
+    {
+        if ($line -match "^port=")
+        {
+            $mySqlPort = ($line -split '=')[1]
+        }
+    }
+    return $mySqlPort
+}
+
+function Get-ArchitectureName
+{
+    <#
+    .SYNOPSIS
+        This function returns the architecture of the server.
+
+    .EXAMPLE
+        Get-ArchitectureName
+        x64
+
+    .EXAMPLE
+        Get-ArchitectureName
+        x86
+    #>
+
+    if($env:PROCESSOR_ARCHITECTURE -eq "AMD64")
+    {
+        return "x64"
+    }
+    else
+    {
+        return "x86"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ The user name can be any non-zero length string, but it will be ignored.
 
 ## Versions
 
-### 1.1.0.0
-
-* Resolved attribute between *.psm1 and *.schema.mof files.
-* Fixed encoding
-
 ### 1.0.0.0
 
 * Initial release with the following resources :

--- a/Tests/MSFT_xMySqlDatabase.Tests.ps1
+++ b/Tests/MSFT_xMySqlDatabase.Tests.ps1
@@ -43,7 +43,7 @@ InModuleScope $DSCResourceName {
 
         Context 'when ErrorPath exists' {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -54,26 +54,23 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
         Context 'when ErrorPath does not exist' {
 
-            Mock Test-Path { return $false }
+            Mock Test-Path -Verifiable { return $false }
             Mock Remove-Item { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
             Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
-            Mock Read-ErrorFile { return }
+            Mock Read-ErrorFile -Verifiable { return }
 
             $result = Get-TargetResource -DatabaseName $databaseName -RootCredential $testCred -MySqlVersion "5.6.17"
 
             It 'should not call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Remove-Item 0
-                Assert-MockCalled Read-ErrorFile 0
             }
         }
 
@@ -201,7 +198,7 @@ InModuleScope $DSCResourceName {
     Describe 'how Set-TargetResource works' {
         Context "when ErrorPath exists" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -212,32 +209,29 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
         Context "when ErrorPath does not exist" {
 
-            Mock Test-Path { return $false }
+            Mock Test-Path -Verifiable { return $false }
             Mock Remove-Item { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
             Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
-            Mock Read-ErrorFile { return }
+            Mock Read-ErrorFile -Verifiable { return }
 
             $null = Set-TargetResource -Ensure "Present" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
 
             It 'should not call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Remove-Item 0
-                Assert-MockCalled Read-ErrorFile 0
             }
         }
 
         Context "when Ensure is 'Present'" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -248,13 +242,12 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
         Context "when Ensure is 'Absent'" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -265,7 +258,6 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
     }

--- a/Tests/MSFT_xMySqlDatabase.Tests.ps1
+++ b/Tests/MSFT_xMySqlDatabase.Tests.ps1
@@ -1,0 +1,273 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (! (Get-Module xDSCResourceDesigner))
+{
+    Import-Module -Name xDSCResourceDesigner
+}
+
+Describe 'Schema Validation MSFT_xMySqlDatabase' {
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlDatabase'
+        $result = Test-xDscResource $path
+        $result | Should Be $true
+    }
+
+    It 'should pass Test-xDscSchema' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlDatabase\MSFT_xMySqlDatabase.schema.mof'
+        $result = Test-xDscSchema $path
+        $result | Should Be $true
+    }
+}
+
+if (Get-Module MSFT_xMySqlDatabase)
+{
+    Remove-Module MSFT_xMySqlDatabase
+}
+
+if (Get-Module xMySql)
+{
+    Remove-Module xMySql
+}
+
+Import-Module (Join-Path $here -ChildPath "..\DSCResources\MSFT_xMySqlDatabase\MSFT_xMySqlDatabase.psm1")
+Import-Module (Join-Path $here -ChildPath "..\xMySql.psd1")
+
+$DSCResourceName = "MSFT_xMySqlDatabase"
+InModuleScope $DSCResourceName {
+
+    $testPassword = ConvertTo-SecureString "password" -AsPlainText -Force
+    $testCred = New-Object -typename System.Management.Automation.PSCredential -argumentlist "account",$testPassword
+
+    Describe "how Get-TargetResource works" {
+        $databaseName = "TestDB"
+
+        Context 'when ErrorPath exists' {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -DatabaseName $databaseName -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context 'when ErrorPath does not exist' {
+
+            Mock Test-Path { return $false }
+            Mock Remove-Item { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
+            Mock Read-ErrorFile { return }
+
+            $result = Get-TargetResource -DatabaseName $databaseName -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Remove-Item 0
+                Assert-MockCalled Read-ErrorFile 0
+            }
+        }
+
+        Context 'when the given database exists' {
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -DatabaseName $databaseName -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'Ensure should be Present' {
+                $result['Ensure'] | should be 'Present'
+            }
+            It "DatabaseName should be $databaseName" {
+                $result['DatabaseName'] | should be $databaseName
+            }
+        }
+
+        Context 'when the given database does not exist' {
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "No" }
+            Mock Read-ErrorFile -Verifiable { return }
+            
+            $result = Get-TargetResource -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'Ensure should be Absent' {
+                $result['Ensure'] | should be 'Absent'
+            }
+            It "DatabaseName should be $databaseName" {
+                $result['DatabaseName'] | should be $databaseName
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource works when Ensure is 'Present'" {
+        Context 'when the given database exists' {
+            $databaseExists = @{
+                Ensure = "Present"
+                DatabaseName = "TestDB"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $databaseExists }
+            
+            $result = Test-TargetResource -Ensure "Present" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true' {
+                $result | should be $true
+            }
+        }
+
+        Context 'when the given database does not exist' {
+            $databaseNotExist = @{
+                Ensure = "Absent"
+                DatabaseName = "TestDB"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $databaseNotExist }
+            
+            $result = Test-TargetResource -Ensure "Present" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false' {
+                $result | should be $false
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource works when Ensure is 'Absent'" {
+        Context 'when the given database exists' {
+            $databaseExists = @{
+                Ensure = "Present"
+                DatabaseName = "TestDB"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $databaseExists }
+            
+            $result = Test-TargetResource -Ensure "Absent" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'return false' {
+                $result | should be $false
+            }
+        }
+
+        Context 'when the given database does not exist' {
+            $databaseNotExist = @{
+                Ensure = "Absent"
+                DatabaseName = "TestDB"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $databaseNotExist }
+            
+            $result = Test-TargetResource -Ensure "Absent" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'return true' {
+                $result | should be $true
+            }
+        }
+    }
+
+    Describe 'how Set-TargetResource works' {
+        Context "when ErrorPath exists" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $null = Set-TargetResource -Ensure "Present" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context "when ErrorPath does not exist" {
+
+            Mock Test-Path { return $false }
+            Mock Remove-Item { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile { return }
+
+            $null = Set-TargetResource -Ensure "Present" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Remove-Item 0
+                Assert-MockCalled Read-ErrorFile 0
+            }
+        }
+
+        Context "when Ensure is 'Present'" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile -Verifiable { return }
+            
+            $null = Set-TargetResource -Ensure "Present" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context "when Ensure is 'Absent'" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "DROP" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $null = Set-TargetResource -Ensure "Absent" -DatabaseName "TestDB" -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+    }
+}
+

--- a/Tests/MSFT_xMySqlGrant.Tests.ps1
+++ b/Tests/MSFT_xMySqlGrant.Tests.ps1
@@ -1,0 +1,340 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (! (Get-Module xDSCResourceDesigner))
+{
+    Import-Module -Name xDSCResourceDesigner
+}
+
+Describe 'Schema Validation MSFT_xMySqlGrant' {
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlGrant'
+        $result = Test-xDscResource $path
+        $result | Should Be $true
+    }
+
+    It 'should pass Test-xDscSchema' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlGrant\MSFT_xMySqlGrant.schema.mof'
+        $result = Test-xDscSchema $path
+        $result | Should Be $true
+    }
+}
+
+if (Get-Module MSFT_xMySqlGrant)
+{
+    Remove-Module MSFT_xMySqlGrant
+}
+
+if (Get-Module xMySql)
+{
+    Remove-Module xMySql
+}
+
+Import-Module (Join-Path $here -ChildPath "..\DSCResources\MSFT_xMySqlGrant\MSFT_xMySqlGrant.psm1")
+Import-Module (Join-Path $here -ChildPath "..\xMySql.psd1")
+
+$DSCResourceName = "MSFT_xMySqlGrant"
+InModuleScope $DSCResourceName {
+
+    $testPassword = ConvertTo-SecureString "password" -AsPlainText -Force
+    $testCred = New-Object -typename System.Management.Automation.PSCredential -argumentlist "account",$testPassword
+
+    Describe "how Get-TargetResource works" {
+        $userName = "TestUser"
+        $databaseName = "TestDB"
+
+        Context "when ErrorPath exists" {
+            $invokeResults = "GRANT USAGE ON *.* TO 'TestUser'@'localhost' IDENTIFIED BY PASSWORD '*326D8F59AB0875382A46BD23BE904264D7CE7EA0'", `
+                "GRANT ALL PRIVILEGES ON `TestDB`.* TO 'TestUser'@'localhost'"
+            $permissionType = "CREATE"
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -UserName $userName -DatabaseName $databaseName -RootCredential $testCred -PermissionType $permissionType -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context "when ErrorPath does not exist" {
+            $invokeResults = "GRANT USAGE ON *.* TO 'TestUser'@'localhost' IDENTIFIED BY PASSWORD '*326D8F59AB0875382A46BD23BE904264D7CE7EA0'", `
+                "GRANT ALL PRIVILEGES ON `TestDB`.* TO 'TestUser'@'localhost'"
+            $permissionType = "CREATE"
+
+            Mock Test-Path { return $false }
+            Mock Remove-Item { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return }
+            Mock Read-ErrorFile { return }
+
+            $result = Get-TargetResource -UserName $userName -DatabaseName $databaseName -RootCredential $testCred -PermissionType $permissionType -MySqlVersion "5.6.17"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Remove-Item 0
+                Assert-MockCalled Read-ErrorFile 0
+            }
+        }
+
+        Context 'when the permission granted is ALL PRIVILEGES' {
+            $invokeResults = "GRANT USAGE ON *.* TO 'TestUser'@'localhost' IDENTIFIED BY PASSWORD '*326D8F59AB0875382A46BD23BE904264D7CE7EA0'", `
+                "GRANT ALL PRIVILEGES ON `TestDB`.* TO 'TestUser'@'localhost'"
+            $permissionType = "CREATE"
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return $invokeResults }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -UserName $userName -DatabaseName $databaseName -RootCredential $testCred -PermissionType $permissionType -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It "UserName should be $userName" {
+                $result['UserName'] | should be $userName
+            }
+            It "DatabaseName should be $databaseName" {
+                $result['DatabaseName'] | should be $databaseName
+            }
+            It 'Ensure should be Present' {
+                $result['Ensure'] | should be 'Present'
+            }
+            It 'PermissionType should be $permissionType' {
+                $result['PermissionType'] | should be $permissionType
+            }
+        }
+
+        Context 'when the given permission matches the permission granted' {
+            $invokeResults = "GRANT USAGE ON *.* TO 'TestUser'@'localhost' IDENTIFIED BY PASSWORD '*326D8F59AB0875382A46BD23BE904264D7CE7EA0'", `
+                "GRANT CREATE, DROP ON `TestDB`.* TO 'TestUser'@'localhost'"
+            $permissionType = "CREATE"
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return $invokeResults }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -UserName $userName -DatabaseName $databaseName -RootCredential $testCred -PermissionType $permissionType -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It "UserName should be $userName" {
+                $result['UserName'] | should be $userName
+            }
+            It "DatabaseName should be $databaseName" {
+                $result['DatabaseName'] | should be $databaseName
+            }
+            It 'Ensure should be Present' {
+                $result['Ensure'] | should be 'Present'
+            }
+            It 'PermissionType should be $permissionType' {
+                $result['PermissionType'] | should be $permissionType
+            }
+        }
+
+        Context 'when the given permission does not match the permission granted' {
+            $invokeResults = "GRANT USAGE ON *.* TO 'TestUser'@'localhost' IDENTIFIED BY PASSWORD '*326D8F59AB0875382A46BD23BE904264D7CE7EA0'", `
+                "GRANT DROP ON `TestDB`.* TO 'TestUser'@'localhost'"
+            $permissionType = "CREATE"
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return $invokeResults }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -UserName $userName -DatabaseName $databaseName -RootCredential $testCred -PermissionType $permissionType -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It "UserName should be $userName" {
+                $result['UserName'] | should be $userName
+            }
+            It "DatabaseName should be $databaseName" {
+                $result['DatabaseName'] | should be $databaseName
+            }
+            It 'Ensure should be Absent' {
+                $result['Ensure'] | should be 'Absent'
+            }
+            It 'PermissionType should be $permissionType' {
+                $result['PermissionType'] | should be $permissionType
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource works when Ensure is 'Present'" {
+        Context 'when the given permission exists' {
+            $permissionExists = @{
+                UserName = "TestUser"
+                DatabaseName = "TestDB"
+                Ensure = "Present"
+                PermissionType = "CREATE"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $permissionExists }
+            
+            $result = Test-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Present" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true' {
+                $result | should be $true
+            }
+        }
+
+        Context 'when the given user does not exist' {
+            $permissionNotExist = @{
+                UserName = "TestUser"
+                DatabaseName = "TestDB"
+                Ensure = "Absent"
+                PermissionType = "CREATE"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $permissionNotExist }
+            
+            $result = Test-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Present" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false' {
+                $result | should be $false
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource works when Ensure is 'Absent'" {
+        Context 'when the given permission exists' {
+            $permissionExists = @{
+                UserName = "TestUser"
+                DatabaseName = "TestDB"
+                Ensure = "Present"
+                PermissionType = "CREATE"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $permissionExists }
+            
+            $result = Test-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Absent" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false' {
+                $result | should be $false
+            }
+        }
+
+        Context 'when the given user does not exist' {
+            $permissionNotExist = @{
+                UserName = "TestUser"
+                DatabaseName = "TestDB"
+                Ensure = "Absent"
+                PermissionType = "CREATE"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $permissionNotExist }
+            
+            $result = Test-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Absent" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true' {
+                $result | should be $true
+            }
+        }
+    }
+
+    Describe 'how Set-TargetResource works' {
+        Context "when ErrorPath exists" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $null = Set-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Present" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Invoke-MySqlCommand -Exactly 1
+            }
+        }
+
+        Context "when ErrorPath does not exist" {
+
+            Mock Test-Path { return $false }
+            Mock Remove-Item { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile { return }
+
+            $null = Set-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Present" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Remove-Item 0
+                Assert-MockCalled Invoke-MySqlCommand -Exactly 1
+                Assert-MockCalled Read-ErrorFile 0
+            }
+        }
+
+        Context "when Ensure is 'Present'" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $null = Set-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Present" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Invoke-MySqlCommand -Exactly 1
+            }
+        }
+
+        Context "when Ensure is 'Absent'" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand { return } -ParameterFilter { $arguments -match "REVOKE" }
+            Mock Read-ErrorFile -Verifiable { return }
+            
+            $null = Set-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Absent" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Invoke-MySqlCommand -Exactly 1
+            }
+        }
+    }
+}

--- a/Tests/MSFT_xMySqlGrant.Tests.ps1
+++ b/Tests/MSFT_xMySqlGrant.Tests.ps1
@@ -47,7 +47,7 @@ InModuleScope $DSCResourceName {
                 "GRANT ALL PRIVILEGES ON `TestDB`.* TO 'TestUser'@'localhost'"
             $permissionType = "CREATE"
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -58,7 +58,6 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
@@ -67,20 +66,18 @@ InModuleScope $DSCResourceName {
                 "GRANT ALL PRIVILEGES ON `TestDB`.* TO 'TestUser'@'localhost'"
             $permissionType = "CREATE"
 
-            Mock Test-Path { return $false }
+            Mock Test-Path -Verifiable { return $false }
             Mock Remove-Item { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
             Mock Invoke-MySqlCommand -Verifiable { return }
-            Mock Read-ErrorFile { return }
+            Mock Read-ErrorFile -Verifiable { return }
 
             $result = Get-TargetResource -UserName $userName -DatabaseName $databaseName -RootCredential $testCred -PermissionType $permissionType -MySqlVersion "5.6.17"
 
             It 'should not call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Remove-Item 0
-                Assert-MockCalled Read-ErrorFile 0
             }
         }
 
@@ -265,7 +262,7 @@ InModuleScope $DSCResourceName {
     Describe 'how Set-TargetResource works' {
         Context "when ErrorPath exists" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -276,34 +273,31 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Invoke-MySqlCommand -Exactly 1
             }
         }
 
         Context "when ErrorPath does not exist" {
 
-            Mock Test-Path { return $false }
+            Mock Test-Path -Verifiable { return $false }
             Mock Remove-Item { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
             Mock Invoke-MySqlCommand { return } -ParameterFilter { $arguments -match "CREATE" }
-            Mock Read-ErrorFile { return }
+            Mock Read-ErrorFile -Verifiable { return }
 
             $null = Set-TargetResource -UserName "TestUser" -DatabaseName "TestDB" -Ensure "Present" -RootCredential $testCred -PermissionType "CREATE" -MySqlVersion "5.6.17"
 
             It 'should not call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Remove-Item 0
                 Assert-MockCalled Invoke-MySqlCommand -Exactly 1
-                Assert-MockCalled Read-ErrorFile 0
             }
         }
 
         Context "when Ensure is 'Present'" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -314,14 +308,13 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Invoke-MySqlCommand -Exactly 1
             }
         }
 
         Context "when Ensure is 'Absent'" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -332,7 +325,6 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Invoke-MySqlCommand -Exactly 1
             }
         }

--- a/Tests/MSFT_xMySqlServer.Tests.ps1
+++ b/Tests/MSFT_xMySqlServer.Tests.ps1
@@ -1,0 +1,292 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (! (Get-Module xDSCResourceDesigner))
+{
+    Import-Module -Name xDSCResourceDesigner
+}
+
+Describe 'Schema Validation MSFT_xMySqlServer' {
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((Get-Item $here).Parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlServer'
+        $result = Test-xDscResource $path
+        $result | Should Be $true
+    }
+
+    It 'should pass Test-xDscSchema' {
+        $path = Join-Path -Path $((Get-Item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlServer\MSFT_xMySqlServer.schema.mof'
+        $result = Test-xDscSchema $path
+        $result | Should Be $true
+    }
+}
+
+if (Get-Module MSFT_xMySqlServer)
+{
+    Remove-Module MSFT_xMySqlServer
+}
+
+if (Get-Module xMySql)
+{
+    Remove-Module xMySql
+}
+
+Import-Module (Join-Path $here -ChildPath "..\DSCResources\MSFT_xMySqlServer\MSFT_xMySqlServer.psm1")
+Import-Module (Join-Path $here -ChildPath "..\xMySql.psd1")
+
+$DSCResourceName = "MSFT_xMySqlServer"
+InModuleScope $DSCResourceName {
+
+    $testPassword = ConvertTo-SecureString "password" -AsPlainText -Force
+    $testCred = New-Object -Typename System.Management.Automation.PSCredential -Argumentlist "account",$testPassword
+
+    Describe 'how Get-TargetResource responds' {
+        $version = "5.6.17"
+
+        Context 'when the given version is installed' {
+            $returnport = "3306"
+            
+            Mock Get-MySqlVersionInstalled -Verifiable { return $true }
+            Mock Get-MySqlPort -Verifiable { return $returnport }
+
+            $result = Get-TargetResource -MySqlVersion $version -RootPassword $testCred
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks Get-MySqlInstalled
+                Assert-VerifiableMocks Get-MySqlPort
+            }
+            It 'Ensure should be Present' {
+                $result['Ensure'] | should be 'Present'
+            }
+            It "MySqlVersion should be $version" {
+                $result['MySqlVersion'] | should be $version
+            }
+            It "Port should be $returnport" {
+                $result['Port'] | should be $returnport
+            }
+        }
+
+        Context 'when the given version is not installed' {
+            
+            Mock Get-MySqlVersionInstalled -Verifiable { return $false }
+            Mock Get-MySqlPort { return }
+
+            $result = Get-TargetResource -MySqlVersion $version -RootPassword $testCred
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Get-MySqlPort 0
+            }
+            It 'Ensure should be Absent'{
+                $result['Ensure'] | should be 'Absent'
+            }
+            It "MySqlVersion should be $version"{
+                $result['MySqlVersion'] | should be $version
+            }
+            It "Port should be null" {
+                $result['Port'] | should be $null
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource responds when Ensure = 'Present'" {
+        Context 'when the given version is installed and port matches' {
+            $MySqlInstalled = @{
+                Ensure = "Present"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlInstalled }
+
+            $result = Test-TargetResource -Ensure "Present" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3306"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true'{
+                $result | should be $true
+            }
+        }
+
+        Context "when the given version is installed and port doesn't match" {
+            $MySqlInstalled = @{
+                Ensure = "Present"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlInstalled }
+
+            $result = Test-TargetResource -Ensure "Present" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false'{
+                $result | should be $false
+            }
+        }
+
+        Context 'when the given version is not installed and the port matches' {
+            $MySqlNotInstalled = @{
+                Ensure = "Absent"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlNotInstalled }
+
+            $result = Test-TargetResource -Ensure "Present" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3306"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false'{
+                $result | should be $false
+            }
+        }
+
+        Context "when the given version is not installed and the port doesn't match" {
+            $MySqlNotInstalled = @{
+                Ensure = "Absent"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlNotInstalled }
+
+            $result = Test-TargetResource -Ensure "Present" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false'{
+                $result | should be $false
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource responds when Ensure = 'Absent'" {
+        Context 'when the given version is installed and the port matches' {
+            $MySqlInstalled = @{
+                Ensure = "Present"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlInstalled }
+
+            $result = Test-TargetResource -Ensure "Absent" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3306"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false'{
+                $result | should be $false
+            }
+        }
+
+        Context "when the given version is installed and port doesn't match" {
+            $MySqlInstalled = @{
+                Ensure = "Present"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlInstalled }
+
+            $result = Test-TargetResource -Ensure "Absent" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false'{
+                $result | should be $false
+            }
+        }
+
+        Context 'when the given version is not installed and the port matches' {
+            $MySqlNotInstalled = @{
+                Ensure = "Absent"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlNotInstalled }
+
+            $result = Test-TargetResource -Ensure "Absent" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3306"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true'{
+                $result | should be $true
+            }
+        }
+
+        Context "when the given version is not installed and the port doesn't match" {
+            $MySqlNotInstalled = @{
+                Ensure = "Absent"
+                MySqlVersion = "5.6.17"
+                Port = "3306"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $MySqlNotInstalled }
+
+            $result = Test-TargetResource -Ensure "Absent" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false'{
+                $result | should be $false
+            }
+        }
+    }
+
+    Describe "how Set-TargetResource works when Ensure is 'Present'" {
+        Context "when no version is installed" {
+
+            Mock Get-MySqlAllInstalled -Verifiable { return $null }
+            Mock Get-MySqlInstallerConsole -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return }
+
+            $null = Set-TargetResource -Ensure "Present" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+        }
+
+        Context "when some version is installed" {
+
+            Mock Get-MySqlAllInstalled -Verifiable { return "5.6.19" }
+            Mock Get-MySqlInstallerConsole { return "C:\somepath" }
+            Mock Invoke-MySqlCommand { return }
+
+            $null = Set-TargetResource -Ensure "Present" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Get-MySqlInstallerConsole 0
+                Assert-MockCalled Invoke-MySqlCommand 0
+            }
+        }
+    }
+
+    Describe "how Set-TargetResource works when Ensure is 'Absent'" {
+        Context "no matter what is installed" {
+
+            Mock Get-MySqlAllInstalled { return $null }
+            Mock Get-MySqlInstallerConsole { return "C:\somepath" }
+            Mock Invoke-MySqlCommand { return }
+
+            $null = Set-TargetResource -Ensure "Absent" -MySqlVersion "5.6.17" -RootPassword $testCred -Port "3307"
+
+            It 'should call all the mocks' {
+                Assert-MockCalled Get-MySqlAllInstalled 0
+                Assert-MockCalled Get-MySqlInstallerConsole 0
+                Assert-MockCalled Invoke-MySqlCommand 0
+            }
+        }
+    }
+}

--- a/Tests/MSFT_xMySqlUser.Tests.ps1
+++ b/Tests/MSFT_xMySqlUser.Tests.ps1
@@ -1,0 +1,272 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (! (Get-Module xDSCResourceDesigner))
+{
+    Import-Module -Name xDSCResourceDesigner
+}
+
+Describe 'Schema Validation MSFT_xMySqlUser' {
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlUser'
+        $result = Test-xDscResource $path
+        $result | Should Be $true
+    }
+
+    It 'should pass Test-xDscSchema' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xMySqlUser\MSFT_xMySqlUser.schema.mof'
+        $result = Test-xDscSchema $path
+        $result | Should Be $true
+    }
+}
+
+if (Get-Module MSFT_xMySqlUser)
+{
+    Remove-Module MSFT_xMySqlUser
+}
+
+if (Get-Module xMySql)
+{
+    Remove-Module xMySql
+}
+
+Import-Module (Join-Path $here -ChildPath "..\DSCResources\MSFT_xMySqlUser\MSFT_xMySqlUser.psm1")
+Import-Module (Join-Path $here -ChildPath "..\xMySql.psd1")
+
+$DSCResourceName = "MSFT_xMySqlUser"
+InModuleScope $DSCResourceName {
+
+    $testPassword = ConvertTo-SecureString "password" -AsPlainText -Force
+    $testCred = New-Object -typename System.Management.Automation.PSCredential -argumentlist "account",$testPassword
+
+    Describe "how Get-TargetResource works" {
+        $userName = "TestUser"
+
+        Context 'when ErrorPath exists' {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -UserName $userName -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context 'when ErrorPath does not exist' {
+
+            Mock Test-Path { return $false }
+            Mock Remove-Item { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
+            Mock Read-ErrorFile { return }
+
+            $result = Get-TargetResource -UserName $userName -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Remove-Item 0
+                Assert-MockCalled Read-ErrorFile 0
+            }
+        }
+
+        Context 'when the given user exists' {
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $result = Get-TargetResource -UserName $userName -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'Ensure should be Present' {
+                $result['Ensure'] | should be 'Present'
+            }
+            It "UserName should be $userName" {
+                $result['UserName'] | should be $userName
+            }
+        }
+
+        Context 'when the given user does not exist' {
+
+            Mock Test-Path -Verifiable { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return "No" }
+            Mock Read-ErrorFile -Verifiable { return }
+            
+            $result = Get-TargetResource -UserName $userName -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'Ensure should be Absent' {
+                $result['Ensure'] | should be 'Absent'
+            }
+            It "UserName should be $userName" {
+                $result['UserName'] | should be $userName
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource works when Ensure is 'Present'" {
+        Context 'when the given user exists' {
+            $userExists = @{
+                Ensure = "Present"
+                UserName = "TestUser"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $userExists }
+            
+            $result = Test-TargetResource -UserName "TestUser" -Ensure "Present" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true' {
+                $result | should be $true
+            }
+        }
+
+        Context 'when the given user does not exist' {
+            $userNotExist = @{
+                Ensure = "Absent"
+                UserName = "TestUser"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $userNotExist }
+            
+            $result = Test-TargetResource -UserName "TestUser" -Ensure "Present" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false' {
+                $result | should be $false
+            }
+        }
+    }
+
+    Describe "how Test-TargetResource works when Ensure is 'Absent'" {
+        Context 'when the given user exists' {
+            $userExists = @{
+                Ensure = "Present"
+                UserName = "TestUser"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $userExists }
+            
+            $result = Test-TargetResource -UserName "TestUser" -Ensure "Absent" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false' {
+                $result | should be $false
+            }
+        }
+
+        Context 'when the given user does not exist' {
+            $userNotExist = @{
+                Ensure = "Absent"
+                UserName = "TestUser"
+            }
+
+            Mock Get-TargetResource -Verifiable { return $userNotExist }
+            
+            $result = Test-TargetResource -UserName "TestUser" -Ensure "Absent" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true' {
+                $result | should be $true
+            }
+        }
+    }
+
+    Describe 'how Set-TargetResource works' {
+        Context "when ErrorPath exists" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $null = Set-TargetResource -UserName "TestUser" -Ensure "Present" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context "when ErrorPath does not exist" {
+
+            Mock Test-Path { return $false }
+            Mock Remove-Item { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile { return }
+
+            $null = Set-TargetResource -UserName "TestUser" -Ensure "Present" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+                Assert-MockCalled Remove-Item 0
+                Assert-MockCalled Read-ErrorFile 0
+            }
+        }
+
+        Context "when Ensure is 'Present'" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
+            Mock Read-ErrorFile -Verifiable { return }
+            
+            $null = Set-TargetResource -UserName "TestUser" -Ensure "Present" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+
+        Context "when Ensure is 'Absent'" {
+
+            Mock Test-Path { return $true }
+            Mock Remove-Item -Verifiable { return }
+            Mock Get-MySqlPort -Verifiable { return "3306" }
+            Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "DROP" }
+            Mock Read-ErrorFile -Verifiable { return }
+
+            $null = Set-TargetResource -UserName "TestUser" -Ensure "Absent" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Test-Path -Exactly 2
+            }
+        }
+    }
+}

--- a/Tests/MSFT_xMySqlUser.Tests.ps1
+++ b/Tests/MSFT_xMySqlUser.Tests.ps1
@@ -43,7 +43,7 @@ InModuleScope $DSCResourceName {
 
         Context 'when ErrorPath exists' {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -54,26 +54,23 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
         Context 'when ErrorPath does not exist' {
 
-            Mock Test-Path { return $false }
+            Mock Test-Path -Verifiable { return $false }
             Mock Remove-Item { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
             Mock Invoke-MySqlCommand -Verifiable { return "Yes" }
-            Mock Read-ErrorFile { return }
+            Mock Read-ErrorFile -Verifiable { return }
 
             $result = Get-TargetResource -UserName $userName -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
 
             It 'should not call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Remove-Item 0
-                Assert-MockCalled Read-ErrorFile 0
             }
         }
 
@@ -201,7 +198,7 @@ InModuleScope $DSCResourceName {
     Describe 'how Set-TargetResource works' {
         Context "when ErrorPath exists" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -212,32 +209,29 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
         Context "when ErrorPath does not exist" {
 
-            Mock Test-Path { return $false }
+            Mock Test-Path -Verifiable { return $false }
             Mock Remove-Item { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
             Mock Invoke-MySqlCommand -Verifiable { return } -ParameterFilter { $arguments -match "CREATE" }
-            Mock Read-ErrorFile { return }
+            Mock Read-ErrorFile -Verifiable { return }
 
             $null = Set-TargetResource -UserName "TestUser" -Ensure "Present" -UserCredential $testCred -RootCredential $testCred -MySqlVersion "5.6.17"
 
             It 'should not call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
                 Assert-MockCalled Remove-Item 0
-                Assert-MockCalled Read-ErrorFile 0
             }
         }
 
         Context "when Ensure is 'Present'" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -248,13 +242,12 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
 
         Context "when Ensure is 'Absent'" {
 
-            Mock Test-Path { return $true }
+            Mock Test-Path -Verifiable { return $true }
             Mock Remove-Item -Verifiable { return }
             Mock Get-MySqlPort -Verifiable { return "3306" }
             Mock Get-MySqlExe -Verifiable { return "C:\somepath" }
@@ -265,7 +258,6 @@ InModuleScope $DSCResourceName {
 
             It 'should call all the mocks' {
                 Assert-VerifiableMocks
-                Assert-MockCalled Test-Path -Exactly 2
             }
         }
     }

--- a/Tests/MSFT_xMySqlUtilities.Tests.ps1
+++ b/Tests/MSFT_xMySqlUtilities.Tests.ps1
@@ -111,14 +111,14 @@ InModuleScope $DSCResourceName {
     }
 
     Describe 'how Get-MySqlVersionInstalled works' {
-        $statusResult = @'
-Your currently installed community products are:
-
-MySQL Server 5.6.17
-         Architecture=X64
-         Installed On 8/27/2015
-         Install Location: C:\Program Files\MySQL\MySQL Server 5.6\
-'@
+        $statusResult = @(
+"Your currently installed community products are:",
+"",
+"MySQL Server 5.6.17",
+"         Architecture=X64",
+"         Installed On 8/27/2015",
+"         Install Location: C:\Program Files\MySQL\MySQL Server 5.6\"
+)
 
         Context 'when the given version is installed' {
 
@@ -153,19 +153,19 @@ MySQL Server 5.6.17
 
     Describe 'how Get-MySqlAllInstalled works' {
         Context 'should find all of the versions' {
-            $statusResult = @'
-Your currently installed community products are:
-
-MySQL Server 5.6.17
-         Architecture=X64
-         Installed On 8/27/2015
-         Install Location: C:\Program Files\MySQL\MySQL Server 5.6\
-
-MySQL Server 5.7.7
-         Architecture=X64
-         Installed On 8/27/2015
-         Install Location: C:\Program Files\MySQL\MySQL Server 5.7\
-'@
+            $statusResult = @(
+"Your currently installed community products are:",
+"",
+"MySQL Server 5.6.17",
+"         Architecture=X64",
+"         Installed On 8/27/2015",
+"         Install Location: C:\Program Files\MySQL\MySQL Server 5.6\",
+"",
+"MySQL Server 5.7.7",
+"         Architecture=X64",
+"         Installed On 8/27/2015",
+"         Install Location: C:\Program Files\MySQL\MySQL Server 5.7\"
+)
 
             $expectedResult = "5.6.17", "5.7.7"
 

--- a/Tests/MSFT_xMySqlUtilities.Tests.ps1
+++ b/Tests/MSFT_xMySqlUtilities.Tests.ps1
@@ -1,0 +1,287 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (! (Get-Module xDSCResourceDesigner))
+{
+    Import-Module -Name xDSCResourceDesigner
+}
+
+if (Get-Module xMySql)
+{
+    Remove-Module xMySql
+}
+
+if (Get-Module MSFT_xMySqlUtilities -All)
+{
+    Get-Module MSFT_xMySqlUtilities -All | Remove-Module
+}
+$breakvar = $true
+Import-Module (Join-Path $here -ChildPath "..\xMySql.psd1")
+
+$DSCResourceName = "MSFT_xMySqlUtilities"
+InModuleScope $DSCResourceName {
+    Describe 'how Invoke-MySqlCommand works' {
+        Context 'when the CommandPath does not exist' {
+            $commandPath = "C:\somepath.exe"
+            $arguments = "test", "test2"
+
+            It 'should throw an error if the CommandPath does not exist' {
+                Mock Test-Path -Verifiable { return $false }
+                { Invoke-MySqlCommand -CommandPath $commandPath -Arguments $arguments } | should throw "$commandPath does not exist"
+            }
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+        }
+    }
+
+    Describe 'how Get-MySqlInstallerConsole works' {
+        Context 'when the Installer Console is installed' {
+
+            Mock Test-Path -Verifiable { return $true }
+
+            $result = Get-MySqlInstallerConsole
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return C:\Program Files (x86)\MySQL\MySQL Installer for Windows\MySQLInstallerConsole.exe' {
+                $result | should be "C:\Program Files (x86)\MySQL\MySQL Installer for Windows\MySQLInstallerConsole.exe"
+            }
+        }
+
+        Context 'when the Installer Console is not installed' {
+
+            It 'should throw an error if the Installer Console is not installed' {
+                Mock Test-Path -Verifiable { return $false }
+                { Get-MySqlInstallerConsole } | should throw "Please ensure that MySQL Installer for Windows is installed"
+            }
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+        }
+    }
+
+    Describe 'how Get-MySqlExe works' {
+        Context 'when the x64 version is installed' {
+            $installPathX64 = "C:\Program Files\MySQL\MySQL Server 5.6\bin\mysql.exe"
+
+            Mock Get-ShortVersion -Verifiable { return 5.6 }
+            Mock Test-Path -Verifiable { return $true } -ParameterFilter { $path -eq $installPathX64 } 
+
+            $result = Get-MySqlExe -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It "should return $installPathX64" {
+                $result | should be $installPathX64
+            }
+        }
+
+        Context 'when the x86 version is installed' {
+            $installPathX64 = "C:\Program Files\MySQL\MySQL Server 5.6\bin\mysql.exe"
+            $installPathX86 = "C:\Program Files (x86)\MySQL\MySQL Server 5.6\bin\mysql.exe"
+
+            Mock Get-ShortVersion -Verifiable { return 5.6 }
+            Mock Test-Path -Verifiable { return $false } -ParameterFilter { $path -eq $installPathX64 } 
+            Mock Test-Path -Verifiable { return $true } -ParameterFilter { $path -eq $installPathX86 } 
+
+            $result = Get-MySqlExe -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It "should return $installPathX86" {
+                $result | should be $installPathX86
+            }
+        }
+
+        Context 'when the version is not installed' {
+
+            It 'should throw an error if that version is not installed' {
+                Mock Get-ShortVersion -Verifiable { return 5.6 }
+                Mock Test-Path -Verifiable { return $false }
+
+                {Get-MySqlExe -MySqlVersion "5.6.17"} | should throw "Please ensure that MySQL Version 5.6 is installed"
+            }
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+        }
+    }
+
+    Describe 'how Get-MySqlVersionInstalled works' {
+        $statusResult = @'
+Your currently installed community products are:
+
+MySQL Server 5.6.17
+         Architecture=X64
+         Installed On 8/27/2015
+         Install Location: C:\Program Files\MySQL\MySQL Server 5.6\
+'@
+
+        Context 'when the given version is installed' {
+
+            Mock Get-MySqlInstallerConsole -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return $statusResult }
+
+            $result = Get-MySqlVersionInstalled -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return true' {
+                $result | should be $true
+            }
+        }    
+
+        Context 'when the given version is not installed' {
+
+            Mock Get-MySqlInstallerConsole -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return $statusResult }
+
+            $result = Get-MySqlVersionInstalled -MySqlVersion "5.6.5"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return false' {
+                $result | should be $false
+            }
+        }    
+    }
+
+    Describe 'how Get-MySqlAllInstalled works' {
+        Context 'should find all of the versions' {
+            $statusResult = @'
+Your currently installed community products are:
+
+MySQL Server 5.6.17
+         Architecture=X64
+         Installed On 8/27/2015
+         Install Location: C:\Program Files\MySQL\MySQL Server 5.6\
+
+MySQL Server 5.7.7
+         Architecture=X64
+         Installed On 8/27/2015
+         Install Location: C:\Program Files\MySQL\MySQL Server 5.7\
+'@
+
+            $expectedResult = "5.6.17", "5.7.7"
+
+            Mock Get-MySqlInstallerConsole -Verifiable { return "C:\somepath" }
+            Mock Invoke-MySqlCommand -Verifiable { return $statusResult }
+
+            $result = Get-MySqlAllInstalled
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'first version should match' {
+                $result[0] | should be $expectedResult[0]
+            }
+            It 'second version should match' {
+                $result[1] | should be $expectedResult[1]
+            }
+        }    
+    }
+
+    Describe 'how Get-ShortVersion works' {
+        Context 'should get the shortened version number' {
+            
+            $result = Get-ShortVersion -MySqlVersion "5.6.17"
+
+            It 'should be 5.6' {
+                $result | should be "5.6"
+            }
+        }
+    }
+
+    Describe 'how Read-ErrorFile works' {
+        Context 'how it works when there is an ERROR in the file' {
+            $mySqlError = "mysql.exe : Warning: Using a password on the command line interface can be insecure.", "At line:11 char:1", "+ & $CommandPath $Arguments", `
+                "+ ~~~~~~~~~~~~~~~~~~~~~~~~~", "    + CategoryInfo          : NotSpecified: (Warning: Using ...an be insecure.:String) [], RemoteException", `
+                "    + FullyQualifiedErrorId : NativeCommandError", "", "ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)"
+
+            It 'should throw an error if there is an ERROR in the file' {
+                Mock Test-Path -Verifiable { return $true }
+                Mock Get-Content -Verifiable { return $mySqlError }
+                Mock Remove-Item { return }
+
+                {Read-ErrorFile -ErrorFilePath C:\somepath} | should throw "ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)"
+            }
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Remove-Item 1
+            }
+        }    
+
+        Context 'how it works when there is not an ERROR in the file' {
+            $mySqlError = "mysql.exe : Warning: Using a password on the command line interface can be insecure.", "At line:11 char:1", "+ & $CommandPath $Arguments", `
+                "+ ~~~~~~~~~~~~~~~~~~~~~~~~~", "    + CategoryInfo          : NotSpecified: (Warning: Using ...an be insecure.:String) [], RemoteException", `
+                "    + FullyQualifiedErrorId : NativeCommandError"
+
+                Mock Test-Path -Verifiable { return $true }
+                Mock Get-Content -Verifiable { return $mySqlError }
+                Mock Remove-Item { return }
+
+            $null = Read-ErrorFile -ErrorFilePath C:\somepath
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Remove-Item 1
+            }
+        }    
+
+        Context 'how it works when the file does not exist' {
+
+                Mock Test-Path -Verifiable { return $false }
+                Mock Get-Content { return $mySqlError }
+                Mock Remove-Item { return }
+
+            $null = Read-ErrorFile -ErrorFilePath C:\somepath
+
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Get-Content 0
+                Assert-MockCalled Remove-Item 0
+            }
+        }    
+    }
+
+    Describe 'how Get-MySqlPort works' {
+        Context 'how it works when the .ini file does not exist' {
+            It 'should throw an error if the .ini file does not exist' {
+
+                Mock Get-ShortVersion -Verifiable { return "5.6" }
+                Mock Join-Path -Verifiable { return "C:\somepath" }
+                Mock Test-Path -Verifiable { return $false }
+                Mock Get-Content { return $myIni }
+
+                {Get-MySqlPort -MySqlVersion "5.6.17"} | should throw "The my.ini file does not exist in the standard location"
+            }
+            It 'should not call all the mocks' {
+                Assert-VerifiableMocks
+                Assert-MockCalled Get-Content 0
+            }
+        }
+
+        Context 'should return the port number' {
+            $myIni = "[client]", "no-beep", "", "# pipe", "# socket=0.0", "port=3306", "", "[mysql]"
+
+            Mock Get-ShortVersion -Verifiable { return "5.6" }
+            Mock Join-Path -Verifiable { return "C:\somepath" }
+            Mock Test-Path -Verifiable { return $true }
+            Mock Get-Content -Verifiable { return $myIni }
+
+            $result = Get-MySqlPort -MySqlVersion "5.6.17"
+
+            It 'should call all the mocks' {
+                Assert-VerifiableMocks
+            }
+            It 'should return port number 3306' {
+                $result | should be "3306"
+            }
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,8 @@
-#---------------------------------# 
-#      environment configuration  # 
-#---------------------------------# 
-version: 1.1.{build}.0
 install: 
-  - cinst -y pester
-  - git clone https://github.com/PowerShell/DscResource.Tests
-  - ps: Push-Location
-  - cd DscResource.Tests
-  - ps: Import-Module .\TestHelper.psm1 -force
-  - ps: Pop-Location
-
-#---------------------------------# 
-#      build configuration        # 
-#---------------------------------# 
+    - cinst -y pester
+    - git clone https://github.com/PowerShell/DscResource.Tests
 
 build: false
-
-#---------------------------------# 
-#      test configuration         # 
-#---------------------------------# 
 
 test_script:
     - ps: |
@@ -28,37 +12,14 @@ test_script:
         if ($res.FailedCount -gt 0) { 
             throw "$($res.FailedCount) tests failed."
         }
-    
-#---------------------------------# 
-#      deployment configuration   # 
-#---------------------------------# 
-
-# scripts to run before deployment 
-before_deploy: 
-  - ps: |
-      # Creating project artifact
-      $stagingDirectory = (Resolve-Path ..).Path
-      $manifest = Join-Path $pwd "xMySql.psd1"
-      (Get-Content $manifest -Raw).Replace("1.1.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
-      $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
-      Add-Type -assemblyname System.IO.Compression.FileSystem
-      [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
-      
-      # Creating NuGet package artifact
-      New-Nuspec -packageName $env:APPVEYOR_PROJECT_NAME -version $env:APPVEYOR_BUILD_VERSION -author "Microsoft" -owners "Microsoft" -licenseUrl "https://github.com/PowerShell/DscResources/blob/master/LICENSE" -projectUrl "https://github.com/$($env:APPVEYOR_REPO_NAME)" -packageDescription $env:APPVEYOR_PROJECT_NAME -tags "DesiredStateConfiguration DSC DSCResourceKit" -destinationPath .
-      nuget pack ".\$($env:APPVEYOR_PROJECT_NAME).nuspec" -outputdirectory .
-      $nuGetPackageName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + ".nupkg"
-      $nuGetPackagePath = (Get-ChildItem $nuGetPackageName).FullName
-      
-      @(
-          # You can add other artifacts here
-          $zipFilePath,
-          $nuGetPackagePath
-      ) | % { 
-          Write-Host "Pushing package $_ as Appveyor artifact"
-          Push-AppveyorArtifact $_
-        }
-        
-        
-
+on_finish:
+    - ps: |
+        $stagingDirectory = (Resolve-Path ..).Path
+        $zipFile = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
+        Add-Type -assemblyname System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFile)
+        @(
+            # You can add other artifacts here
+            (ls $zipFile)
+        ) | % { Push-AppveyorArtifact $_.FullName }
 

--- a/xMySql.psd1
+++ b/xMySql.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '1.0.0.1'
+ModuleVersion = '1.0.0.0'
 
 # ID used to uniquely identify this module
 GUID = '7c3fee65-807c-4c25-8f60-0dbece96d1bb'

--- a/xMySql.psd1
+++ b/xMySql.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '1.1.0.0'
+ModuleVersion = '1.0.0.1'
 
 # ID used to uniquely identify this module
 GUID = '7c3fee65-807c-4c25-8f60-0dbece96d1bb'
@@ -25,6 +25,9 @@ CLRVersion = '4.0'
 
 # Script module or binary module file associated with this manifest.
 #RootModule = 'PSWSIISEndpoint.psm1'
+
+# Modules to import as nested modules of the module specified in ModuleToProcess
+NestedModules = 'MSFT_xMySqlUtilities.psm1'
 
 # Functions to export from this module
 FunctionsToExport = '*'


### PR DESCRIPTION
Added tests for everything.
Created MSFT_xMySqlUtilities.psm1 to hold all of the functions used by the various Get, Set, and Test functions and added it as a nested module.

Changes to xMySqlProvision.Schema.psm1:
Removed ServiceName as an input and using the default instead.
Added validation to several inputs.
Added Port as an input so you don't have to use the default port.
Added PermissionType so you can specify what permissions you want to give to the user.
Added MySQLVersion as an input parameter (and removed the version constant in the other modules) so that you can manage whatever version of MySQL you want.
Updated the ProductId and Name for installing the MySQL Installer Console.
Updated the inputs to the various module calls to account for added or removed inputs.
Removed references to WordPress.

Changes to the rest of the modules:
Updated the schema file to reflect the changes to the inputs.
Removed the version constants.
Moved helper functions to MSFT_xMySqlUtilities.psm1
Modified the inputs to have more descriptive names and added validation.
Changed the MySQL commands so that they work and added some error handling. Also streamlined some of the functionality.
Removed [CmdletBinding(SupportsShouldProcess=$true)] since it wasn't implemented.
